### PR TITLE
Fix typo in privilege name

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The lambda IAM role must have at least the following policy attached:
         },
         {
             "Action": [
-                "route53:ListRessourceRecordSets",
+                "route53:ListResourceRecordSets",
                 "route53:ChangeResourceRecordSets"
             ],
             "Resource": "arn:aws:route53:::hostedzone/*",

--- a/main.tf
+++ b/main.tf
@@ -65,7 +65,7 @@ resource "aws_iam_role_policy" "asg_ddns_lambda_policy" {
         },
         {
             "Action": [
-                "route53:ListRessourceRecordSets",
+                "route53:ListResourceRecordSets",
                 "route53:ChangeResourceRecordSets"
             ],
             "Resource": "arn:aws:route53:::hostedzone/*",


### PR DESCRIPTION
Simple typo. Caught this porting the policy into a cloudformation template. :) Thanks for posting this, BTW, it's exactly the code I needed, for when a full-on load balancer is too much. Fixes #1 